### PR TITLE
feat: ✨ Implement Shortcut for Service Order Template with Auto-fill

### DIFF
--- a/src/components/OmniMaxPopup.svelte
+++ b/src/components/OmniMaxPopup.svelte
@@ -8,7 +8,7 @@
    *
    * @component
    */
-  import { onMount, createEventDispatcher } from "svelte";
+  import { onMount } from "svelte";
   import CollapsibleSection from "./CollapsibleSection.svelte";
   import ToggleSwitch from "./ToggleSwitch.svelte";
   import {
@@ -18,7 +18,6 @@
     ListChecks,
     XCircle,
     Info,
-    Github,
   } from "lucide-svelte";
 
   import {
@@ -39,9 +38,7 @@
   } from "../storage";
 
   import { availableModules, type Module } from "../modules"; // Import Module type
-    import GithubMarkIcon from "./icons/GithubMarkIcon.svelte";
-
-  const dispatch = createEventDispatcher();
+  import GithubMarkIcon from "./icons/GithubMarkIcon.svelte";
 
   // --- UI Control States ---
   /** Indicates if the component is currently loading initial settings. */
@@ -93,7 +90,11 @@
   );
   /** Modules categorized as 'shortcuts' for UI grouping. */
   const shortcutModules: Module[] = availableModules.filter((m) =>
-    ["shortcutCopyName", "shortcutCopyDocumentNumber"].includes(m.id),
+    [
+      "shortcutCopyName",
+      "shortcutCopyDocumentNumber",
+      "shortcutServiceOrderTemplate",
+    ].includes(m.id),
   );
   /** Modules categorized as 'AI features' for UI grouping. */
   const aiModules: Module[] = availableModules.filter((m) =>
@@ -234,10 +235,15 @@
           let defaultKey = defaultShortcutValues[module.id];
           if (!defaultKey) {
             // Fallback if not in store's initial value
-            if (module.id === "shortcutCopyName") defaultKey = "Z";
-            else if (module.id === "shortcutCopyDocumentNumber")
-              defaultKey = "X";
-            else defaultKey = "?";
+            defaultKey =
+              (shortcutKeysStore as any).initialValue?.[module.id] || // Tenta pegar do default do store
+              (module.id === "shortcutCopyName"
+                ? "Z"
+                : module.id === "shortcutCopyDocumentNumber"
+                  ? "X"
+                  : module.id === "shortcutServiceOrderTemplate"
+                    ? "S"
+                    : "?");
           }
           currentLocal[module.id] = storedKeys[module.id] ?? defaultKey;
           if (isFirstSubscriptionCall) {
@@ -427,8 +433,7 @@
         class="github-link-header"
         title="Ver repositório do Omni Max no GitHub"
       >
-
-      <GithubMarkIcon size={20} className="github-svg-icon" />
+        <GithubMarkIcon size={20} className="github-svg-icon" />
       </a>
     </div>
   </div>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -22,12 +22,40 @@ export interface Config {
      * for the customer's CPF label. Example: 'small > strong' if 'CPF Cliente:' is in a <strong>
      * inside a <small> tag that also contains the CPF value.
      */
-    cpfLabelElement: string;
+    cpfInfoContainer: string;
+    /**
+     * Selector for an element that is a reliable ancestor or direct identifier
+     * for the customer's CPF label, used in a container that may include other elements.
+     * Example: 'small > strong' if the CPF label is in a <strong> inside a <small> tag.
+     * This is used to ensure the CPF label can be found even if the structure changes.
+     */
+    cpfLabelQueryInContainer: string;
     /**
      * Selector for an element that is a reliable ancestor or direct identifier
      * for the customer's name label.
      */
-    nameLabelElement: string;
+    nameInfoContainer: string;
+    /**
+     * Selector for an element that is a reliable ancestor or direct identifier
+     * for the customer's phone number information.
+     */
+    phoneInfoContainer: string;
+
+    /**
+     * Selector for an element that is a reliable ancestor or direct identifier
+     * for the customer's phone number label, used in a container that may include other elements.
+     */
+    phoneLabelQueryInContainer: string;
+    /**
+     * Selector for an element that is a reliable ancestor or direct identifier
+     * for the customer's protocol information.
+     */
+    protocolInfoContainer: string;
+    /**
+     * Selector for an element that is a reliable ancestor or direct identifier
+     * for the customer's protocol label, used in a container that may include other elements.
+     */
+    protocolLabelQueryInContainer: string;
     /**
      * Optional selector for the list of tabs/conversations,
      * primarily used for layout correction adjustments.
@@ -51,6 +79,10 @@ export interface Config {
      * to isolate the customer's name (e.g., ' - ' in "Matrícula: 123 - John Doe").
      */
     customerNameSeparator?: string;
+    /** The exact text label that precedes the customer's phone number. */
+    phoneLabel: string;
+    /** The exact text label that precedes the customer's protocol number. */
+    protocolLabel: string;
   };
 }
 
@@ -62,13 +94,20 @@ export const CONFIG: Config = Object.freeze({
   selectors: {
     conversaContainer: '.tab-pane.active .conversa.col-lg-12',
     editableChatbox: "#Abas .tab-pane.active .faketextbox.pastable[contenteditable='true']",
-    cpfLabelElement: 'small > strong', // Assumes CPF label is a <strong> inside a <small>
-    nameLabelElement: 'small', // Assumes name information is within a <small> tag
+    cpfInfoContainer: 'small',
+    cpfLabelQueryInContainer: 'strong', 
+    nameInfoContainer: 'small',
+    phoneInfoContainer: 'small',
+    phoneLabelQueryInContainer: 'strong',
+    protocolInfoContainer: 'small',
+    protocolLabelQueryInContainer: 'strong',
     tabsList: '#tabs',
   },
   textMarkers: {
     cpfLabel: 'CPF Cliente:',
     customerNameIndicator: 'Matrícula:',
     customerNameSeparator: ' - ',
+    phoneLabel: 'Telefone:',
+    protocolLabel: 'Número de protocolo:',
   },
 });

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -42,6 +42,12 @@ export const availableModules: Module[] = [
     defaultEnabled: true,
   },
   {
+    id: 'shortcutServiceOrderTemplate',
+    name: 'Atalho: Template de Ordem de Serviço',
+    description: 'Copia um template de Ordem de Serviço para a área de transferência com Telefone e Protocolo pré-preenchidos (padrão: Ctrl+Shift+S).',
+    defaultEnabled: true, // Habilitado por padrão, você decide
+  },
+  {
     id: 'templateProcessor',
     name: 'Processador de Templates de Mensagens',
     description: 'Ajusta o nome do cliente ({ANA MARIA} => Ana), auto seleciona variavel ([VARIAVEL]) com Tab.',

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -178,5 +178,6 @@ export const shortcutKeysStore = persistentStore<ShortcutKeysConfig>(
   {
     shortcutCopyName: 'Z',
     shortcutCopyDocumentNumber: 'X',
+    shortcutServiceOrderTemplate: 'S',
   }
 );


### PR DESCRIPTION
This PR introduces a new keyboard shortcut to generate a pre-filled Service Order (OS) template, aiming to streamline the agent's workflow on the Matrix Go platform.

**Functionality Implemented:**

* **New Keyboard Shortcut:**
    * A configurable shortcut (defaulting to `Ctrl+Shift+S`, or as defined in `shortcutKeysStore`) triggers the generation of a Service Order template.
    * This feature can be enabled/disabled via its specific toggle in the "Atalhos de Teclado" section of the Omni Max popup.
    * The shortcut key itself can be customized in the popup.

* **Service Order Template:**
    * The generated template has the following structure:
        ```
        Situação: [RELATO_DO_CLIENTE] |||
        Telefone: [TELEFONE_EXTRAIDO] |||
        Protocolo: [PROTOCOLO_EXTRAIDO] |||
        OBS: [OBSERVAÇÕES]
        ```
    * **Auto-filled Fields:**
        * `[TELEFONE_EXTRAIDO]`: The customer's phone number is extracted from the page. If not found, the placeholder `[TELEFONE]` (or similar) is used.
        * `[PROTOCOLO_EXTRAIDO]`: The current service protocol number is extracted from the page. If not found, the placeholder `[PROTOCOLO]` (or similar) is used.
    * **User-defined Placeholders:** `[RELATO_DO_CLIENTE]` and `[OBSERVAÇÕES]` are kept as placeholders for the agent to fill in.

* **Action:**
    * The fully constructed template string is copied to the clipboard.
    * A toast notification informs the user of the action's outcome (e.g., "Template de Ordem de Serviço copiado!", "Telefone não encontrado.", etc.).

**Technical Changes:**

* **`src/modules.ts`:** Added a new module definition for `shortcutServiceOrderTemplate`.
* **`src/storage.ts`:** Updated `shortcutKeysStore` with a default key for the new shortcut.
* **`src/components/OmniMaxPopup.svelte`:** The new shortcut module is now listed and configurable in the "Atalhos de Teclado" section.
* **`src/content/config.ts`:** Added new DOM selectors and text markers for extracting "Telefone" and "Número de protocolo".
* **`src/content/services/ExtractionService.ts`:** Implemented `extractPhoneNumber()` and `extractProtocolNumber()` methods.
* **`src/content/services/ShortcutService.ts`:** Added a new action to `actionsMap` to handle the service order template generation, calling the new extraction methods and constructing the template string.

**Related Issue:**

* Closes #17 *

This feature further enhances agent productivity by reducing manual data entry for service order creation.