### PR TITLE
test: ✅ add unit tests for module definitions and initial states

### DIFF
--- a/src/__snapshots__/modules.test.ts.snap
+++ b/src/__snapshots__/modules.test.ts.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`availableModules > should match the snapshot of available modules 1`] = `
+[
+  {
+    "defaultEnabled": true,
+    "description": "Move a lista de conversas para a direia e limita a altura 70% da tela para melhor usabilidade.",
+    "id": "layoutCorrection",
+    "name": "Correção de Layout",
+  },
+  {
+    "defaultEnabled": true,
+    "description": "Permite copiar o nome do cliente usando um atalho de teclado (padrão: Ctrl+Shift+Z).",
+    "id": "shortcutCopyName",
+    "name": "Atalho: Copiar Nome do Cliente",
+  },
+  {
+    "defaultEnabled": true,
+    "description": "Permite copiar o Número do Documento do cliente usando um atalho de teclado (padrão: Ctrl+Shift+X).",
+    "id": "shortcutCopyDocumentNumber",
+    "name": "Atalho: Copiar Número do Documento do Cliente",
+  },
+  {
+    "defaultEnabled": true,
+    "description": "Copia um template de Ordem de Serviço para a área de transferência com Telefone e Protocolo pré-preenchidos (padrão: Ctrl+Shift+S).",
+    "id": "shortcutServiceOrderTemplate",
+    "name": "Atalho: Template de Ordem de Serviço",
+  },
+  {
+    "defaultEnabled": true,
+    "description": "Ajusta o nome do cliente ({ANA MARIA} => Ana), auto seleciona variavel ([VARIAVEL]) com Tab.",
+    "id": "templateProcessor",
+    "name": "Processador de Templates de Mensagens",
+  },
+  {
+    "defaultEnabled": false,
+    "description": "Gera um resumo do histórico da conversa (protocolo) atual utilizando Inteligência Artificial.",
+    "id": "aiChatSummary",
+    "name": "IA: Resumir Atendimento",
+  },
+  {
+    "defaultEnabled": false,
+    "description": "Utiliza IA para analisar e sugerir melhorias no texto da sua resposta antes do envio.",
+    "id": "aiResponseReview",
+    "name": "IA: Revisar e Melhorar Resposta",
+  },
+]
+`;

--- a/src/modules.test.ts
+++ b/src/modules.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @file modules.test.ts
+ * @description Unit tests for module definitions and utility functions
+ * as defined in `src/modules.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  availableModules,
+  getInitialModuleStates,
+  type Module,
+} from './modules';
+
+/**
+ * Test suite for the `availableModules` constant.
+ * It verifies the structure, content, and integrity of the defined modules.
+ */
+describe('availableModules', () => {
+  /**
+   * Verifies that `availableModules` is an array.
+   */
+  it('should be an array', () => {
+    expect(Array.isArray(availableModules)).toBe(true);
+  });
+
+  /**
+   * Ensures that the `availableModules` array is not empty,
+   * implying that there are modules defined.
+   */
+  it('should not be empty', () => {
+    expect(availableModules.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Checks each module in `availableModules` to ensure it conforms to the `Module` interface,
+   * possessing all required properties (`id`, `name`, `description`, `defaultEnabled`)
+   * with the correct data types and non-empty string values.
+   */
+  it('each module should have the required properties, correct types, and non-empty string values', () => {
+    availableModules.forEach((module: Module) => {
+      expect(module).toHaveProperty('id');
+      expect(typeof module.id).toBe('string');
+      expect(module.id).not.toBe('');
+
+      expect(module).toHaveProperty('name');
+      expect(typeof module.name).toBe('string');
+      expect(module.name).not.toBe('');
+
+      expect(module).toHaveProperty('description');
+      expect(typeof module.description).toBe('string');
+      expect(module.description).not.toBe('');
+
+      expect(module).toHaveProperty('defaultEnabled');
+      expect(typeof module.defaultEnabled).toBe('boolean');
+    });
+  });
+
+  /**
+   * Validates that all module IDs within `availableModules` are unique.
+   * Duplicate IDs could lead to conflicts in module management and state.
+   */
+  it('all module IDs should be unique', () => {
+    const ids = availableModules.map(module => module.id);
+    const uniqueIds = new Set(ids);
+    expect(ids.length).toBe(uniqueIds.size);
+  });
+
+  /**
+   * Snapshot test for `availableModules`.
+   * This ensures that the structure and content of the modules remain consistent
+   * across changes, helping to catch unintended modifications.
+   */
+  
+  it('should match the snapshot of available modules', () => {
+    expect(availableModules).toMatchSnapshot();
+  });
+  
+});
+
+/**
+ * Test suite for the `getInitialModuleStates` function.
+ * It verifies that the function correctly generates an initial state object
+ * based on the `availableModules`.
+ */
+describe('getInitialModuleStates', () => {
+  /**
+   * Ensures that `getInitialModuleStates` returns a non-null object.
+   */
+  it('should return a non-null object', () => {
+    const initialStates = getInitialModuleStates();
+    expect(typeof initialStates).toBe('object');
+    expect(initialStates).not.toBeNull();
+  });
+
+  /**
+   * Verifies that the returned object from `getInitialModuleStates` contains a key
+   * for every module ID defined in `availableModules`, and no more or fewer keys.
+   */
+  it('should return an object with keys corresponding to all module IDs', () => {
+    const initialStates = getInitialModuleStates();
+    const moduleIds = availableModules.map(module => module.id);
+
+    expect(Object.keys(initialStates).length).toBe(moduleIds.length);
+    moduleIds.forEach(id => {
+      expect(initialStates).toHaveProperty(id);
+    });
+  });
+
+  /**
+   * Checks if the value for each module ID in the returned state object
+   * correctly reflects the `defaultEnabled` status of the corresponding module.
+   */
+  it('should set the correct defaultEnabled status for each module ID', () => {
+    const initialStates = getInitialModuleStates();
+    availableModules.forEach(module => {
+      expect(initialStates[module.id]).toBe(module.defaultEnabled);
+    });
+  });
+
+  /**
+   * Verifies the behavior of `getInitialModuleStates` if `availableModules` were empty.
+   * Given `availableModules` is a constant, this test primarily confirms the function's
+   * robustness to an empty input array, which would result in an empty state object.
+   */
+  it('should return an empty object if availableModules is empty (conceptual)', () => {
+    // This test case is conceptual for an empty `availableModules` array.
+    // Since `availableModules` is a non-empty constant in the actual module,
+    // we can't easily mock it to be empty in this specific test without complex module mocking.
+    // However, the logic of `getInitialModuleStates` (a simple loop) inherently means
+    // if `availableModules` were `[]`, the result would be `{}`.
+    // The other tests already cover its behavior with the actual `availableModules`.
+    // If `availableModules` could truly be empty at runtime from an external source,
+    // more direct mocking would be warranted.
+
+    // For documentation: if `availableModules` was `[]`, then:
+    // const hypotheticalEmptyModules: Module[] = [];
+    // const result = {}; // What getInitialModuleStates would compute
+    // actualAvailableModules.forEach(m => result[m.id] = m.defaultEnabled ) based on hypotheticalEmptyModules
+    // expect(result).toEqual({});
+    // This confirms the function's inherent behavior.
+
+    // Test with actual `availableModules` to ensure no regression:
+    if (availableModules.length === 0) {
+      // This branch will likely not be hit given `availableModules` definition.
+      expect(getInitialModuleStates()).toEqual({});
+    } else {
+      // This is effectively tested by 'should return an object with keys corresponding to all module IDs'
+      // and 'should set the correct defaultEnabled status for each module ID'.
+      // We assert that it's not empty as a basic sanity check here for the "else" branch.
+      expect(Object.keys(getInitialModuleStates()).length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
This pull request introduces unit tests for the `src/modules.ts` file, which defines the available modules within the Omni Max extension and their initial states. These tests aim to ensure the integrity and correctness of the module configurations.

**Key Changes:**

* **Created `src/modules.test.ts`**: A new test file co-located with `src/modules.ts`.
* **Tests for `availableModules` Constant**:
    * Verified that `availableModules` is a non-empty array.
    * Ensured each module object within the array adheres to the `Module` interface, checking for the presence and correct types of `id`, `name`, `description`, and `defaultEnabled` properties.
    * Validated that all module `id`s are unique to prevent conflicts.
* **Tests for `getInitialModuleStates()` Function**:
    * Confirmed that the function returns a non-null object.
    * Verified that the keys of the returned object correspond to all `id`s defined in `availableModules`.
    * Ensured that the boolean value for each module ID correctly reflects its `defaultEnabled` status.

**Benefits:**

* Increases test coverage for core application logic.
* Helps in early detection of potential issues related to module definitions (e.g., duplicate IDs, missing or malformed properties).
* Serves as living documentation for the expected structure and behavior of the module system.

These tests are pure unit tests and do not involve complex mocks, as `modules.ts` primarily contains data definitions and pure functions.