### PR TITLE
feat(DomService): ✨ Add createElementWithOptions method and tests

### DIFF
--- a/src/content/services/DomService.test.ts
+++ b/src/content/services/DomService.test.ts
@@ -402,4 +402,76 @@ describe('DomService', () => {
       expect(editableDiv.scrollTop).toBe(editableDiv.scrollHeight);
     });
   });
+
+  describe('createElementWithOptions', () => {
+    it('should create an element with the specified tag name', () => {
+        const div = domService.createElementWithOptions('div');
+        expect(div).toBeInstanceOf(HTMLDivElement);
+        expect(div.tagName).toBe('DIV');
+    });
+
+    it('should set ID if provided', () => {
+        const p = domService.createElementWithOptions('p', { id: 'my-paragraph' });
+        expect(p.id).toBe('my-paragraph');
+    });
+
+    it('should set a single class name if provided as string', () => {
+        const span = domService.createElementWithOptions('span', { className: 'my-class' });
+        expect(span.classList.contains('my-class')).toBe(true);
+    });
+
+    it('should set multiple class names if provided as array', () => {
+        const article = domService.createElementWithOptions('article', { className: ['class1', 'class2'] });
+        expect(article.classList.contains('class1')).toBe(true);
+        expect(article.classList.contains('class2')).toBe(true);
+    });
+
+    it('should set textContent if provided', () => {
+        const h1 = domService.createElementWithOptions('h1', { textContent: 'Hello Title' });
+        expect(h1.textContent).toBe('Hello Title');
+    });
+
+    it('should apply styles if provided', () => {
+        const styles: Partial<CSSStyleDeclaration> = { color: 'rgb(0, 0, 255)', marginLeft: '10px' };
+        // Espiona o método applyStyles da instância atual de domService
+        const applyStylesSpy = vi.spyOn(domService, 'applyStyles');
+        const section = domService.createElementWithOptions('section', { styles });
+
+        expect(applyStylesSpy).toHaveBeenCalledWith(section, styles);
+        // Verificação real do estilo (opcional, pois applyStyles já é testado, mas bom para integração)
+        expect(section.style.color).toBe('rgb(0, 0, 255)');
+        expect(section.style.marginLeft).toBe('10px');
+        applyStylesSpy.mockRestore(); // Restaura o spy
+    });
+
+    it('should append to parent if provided', () => {
+        const parentDiv = document.createElement('div');
+        testContainer.appendChild(parentDiv); // testContainer é do beforeEach geral
+        const childP = domService.createElementWithOptions('p', { parent: parentDiv, textContent: 'child' });
+
+        expect(parentDiv.contains(childP)).toBe(true);
+        expect(parentDiv.textContent).toBe('child');
+    });
+
+    it('should set attributes if provided', () => {
+        const input = domService.createElementWithOptions('input', { 
+            attributes: { type: 'text', placeholder: 'Enter here', 'data-custom': 'value' } 
+        });
+        expect(input.getAttribute('type')).toBe('text');
+        expect(input.getAttribute('placeholder')).toBe('Enter here');
+        expect(input.getAttribute('data-custom')).toBe('value');
+    });
+
+    it('should handle empty options object', () => {
+        const el = domService.createElementWithOptions('a', {});
+        expect(el).toBeInstanceOf(HTMLAnchorElement);
+        expect(el.id).toBe('');
+        expect(el.textContent).toBe('');
+    });
+
+    it('should handle undefined options', () => {
+        const el = domService.createElementWithOptions('button', undefined);
+        expect(el).toBeInstanceOf(HTMLButtonElement);
+    });
+});
 });

--- a/src/content/services/DomService.ts
+++ b/src/content/services/DomService.ts
@@ -122,4 +122,68 @@ export class DomService {
     // Ensure the new cursor position is visible by scrolling to the bottom of the element.
     element.scrollTop = element.scrollHeight;
   }
+
+  /**
+   * Creates an HTML element with specified options, optionally sets its text content,
+   * applies styles, and appends it to a parent node.
+   *
+   * @template K The tag name of the element to create (e.g., 'div', 'span').
+   * @param {K} tagName The HTML tag name for the element to be created.
+   * @param {object} [options] Optional configuration for the new element.
+   * @param {string} [options.id] The ID to set for the element.
+   * @param {string | string[]} [options.className] A class name or array of class names to add.
+   * @param {string} [options.textContent] The text content to set for the element.
+   * @param {Partial<CSSStyleDeclaration>} [options.styles] CSS styles to apply to the element.
+   * @param {Node} [options.parent] The parent node to which the new element will be appended.
+   * @param {Record<string, string>} [options.attributes] A map of attributes to set on the element.
+   * @returns {HTMLElementTagNameMap[K]} The created HTML element.
+   */
+  createElementWithOptions<K extends keyof HTMLElementTagNameMap>(
+    tagName: K,
+    options?: {
+      id?: string;
+      className?: string | string[];
+      textContent?: string;
+      styles?: Partial<CSSStyleDeclaration>;
+      parent?: Node;
+      attributes?: Record<string, string>;
+    }
+  ): HTMLElementTagNameMap[K] {
+    const element = document.createElement(tagName);
+
+    if (options?.id) {
+      element.id = options.id;
+    }
+
+    if (options?.className) {
+      if (Array.isArray(options.className)) {
+        element.classList.add(...options.className);
+      } else {
+        element.classList.add(options.className);
+      }
+    }
+
+    if (options?.textContent) {
+      element.textContent = options.textContent;
+    }
+
+    if (options?.attributes) {
+        for (const [key, value] of Object.entries(options.attributes)) {
+            element.setAttribute(key, value);
+        }
+    }
+
+    // Reutiliza o método applyStyles existente se houver estilos
+    if (options?.styles && Object.keys(options.styles).length > 0) {
+      // applyStyles espera um Element, e createElement retorna um tipo mais específico
+      // que é um subtipo de Element, então está ok.
+      this.applyStyles(element, options.styles);
+    }
+
+    if (options?.parent) {
+      options.parent.appendChild(element);
+    }
+
+    return element;
+  }
 }


### PR DESCRIPTION
This PR enhances the `DomService` by adding a new utility method `createElementWithOptions`. This method simplifies the creation of HTML elements, allowing for simultaneous setting of ID, class names, text content, styles, attributes, and appending to a parent.

**Key Changes:**

* Added `createElementWithOptions<K extends keyof HTMLElementTagNameMap>(tagName: K, options?: { ... })` to `DomService.ts`.
* Implemented comprehensive unit tests in `DomService.test.ts` for the new method, covering:
    * Element creation with various tag names.
    * Setting ID, single/multiple class names, and text content.
    * Application of inline styles (reusing the existing `applyStyles` method).
    * Setting custom attributes.
    * Appending the created element to a specified parent node.
    * Handling of empty or undefined options.

This addition makes `DomService` more versatile and supports cleaner DOM manipulation in other services.