### PR TITLE
refactor(NotificationService): ♻️ Utilize DomService for DOM tasks and update tests

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -37,7 +37,7 @@ function initializeOmniMaxContentScript(): void {
   // Instantiate core services (Dependency Injection)
   const domService = new DomService();
   const clipboardService = new ClipboardService();
-  const notificationService = new NotificationService();
+  const notificationService = new NotificationService(domService);
   const extractionService = new ExtractionService(CONFIG, domService);
 
   // Initialize feature-specific services and attach their listeners

--- a/src/content/services/NotificationService.test.ts
+++ b/src/content/services/NotificationService.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @file src/content/services/NotificationService.test.ts
+ * @description Unit tests for the NotificationService class.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NotificationService } from './NotificationService';
+import { DomService } from './DomService'; // Importa a classe real para que o vi.mock funcione corretamente
+
+// --- Constantes de Estilo e Cores ---
+const toastBaseStylesFromNotificationService: Partial<CSSStyleDeclaration> = {
+    position: 'fixed',
+    bottom: '20px',
+    right: '20px',
+    padding: '12px 20px',
+    borderRadius: '6px',
+    color: 'white',
+    zIndex: '2147483647',
+    fontFamily: expect.any(String),
+    fontSize: '14px',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+};
+
+const toastTypeColors: Record<string, string> = {
+    success: '#2ecc71',
+    warning: '#f39c12',
+    error: '#e74c3c',
+};
+
+// --- Mock da DomService ---
+const mockToastElement = document.createElement('div'); // Elemento mock que será "criado"
+// Adicionamos um spy no método remove DESTE elemento específico
+vi.spyOn(mockToastElement, 'remove');
+
+const mockDomServiceInstance = {
+    createElementWithOptions: vi.fn().mockReturnValue(mockToastElement),
+    applyStyles: vi.fn(),
+    waitNextFrame: vi.fn().mockResolvedValue(undefined), // Simula que o frame passou
+    // Adicione outros métodos da DomService que NotificationService possa usar
+};
+
+// Mocka o módulo DomService. Todas as instâncias de DomService usarão este mock.
+vi.mock('./DomService', () => {
+    // O construtor mockado da DomService deve retornar nossa instância mockada
+    return {
+        DomService: vi.fn(() => mockDomServiceInstance),
+    };
+});
+
+describe('NotificationService (with mocked DomService)', () => {
+    let notificationService: NotificationService;
+    // Não precisamos mais de appendChildSpy nem rafSpy aqui, pois DomService é mockada
+
+    beforeEach(() => {
+        // Limpa todos os mocks ANTES de cada teste para garantir um estado limpo
+        vi.resetAllMocks();
+
+        // Configura o mock de createElementWithOptions para retornar o mockToastElement limpo
+        // (seu spy de 'remove' também será resetado por resetAllMocks se o elemento for recriado,
+        // mas como mockToastElement é global ao describe, seu spy é persistente a menos que recriado)
+        // Se mockToastElement.remove foi chamado em um teste anterior, seu spy terá chamadas.
+        // Para garantir que 'remove' esteja limpo para cada teste:
+        vi.spyOn(mockToastElement, 'remove').mockClear(); // Limpa chamadas do spy de remove
+        mockDomServiceInstance.createElementWithOptions.mockReturnValue(mockToastElement);
+        mockDomServiceInstance.waitNextFrame.mockResolvedValue(undefined);
+
+
+        // Cria uma instância de NotificationService.
+        // O construtor de DomService (importado) é mockado para retornar mockDomServiceInstance.
+        // Portanto, `new DomService()` dentro do construtor de NotificationService
+        // (ou se passado como argumento) usará o mock.
+        const domServiceInjected = new DomService(); // Isso vai retornar mockDomServiceInstance
+        notificationService = new NotificationService(domServiceInjected);
+
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers(); // Executa timers pendentes
+        vi.useRealTimers();     // Restaura timers reais
+        // vi.restoreAllMocks(); // Já chamado implicitamente por resetAllMocks no beforeEach do próximo teste
+                               // ou no vitest-setup.ts. Se não, adicione aqui.
+    });
+
+    it('should create, animate, and remove a success toast with default duration', async () => {
+        const message = 'Success!';
+        notificationService.showToast(message); // type 'success' e duration 3000 por padrão
+
+        // 1. Verifica DomService.createElementWithOptions
+        expect(mockDomServiceInstance.createElementWithOptions).toHaveBeenCalledOnce();
+        const createElementArgs = mockDomServiceInstance.createElementWithOptions.mock.calls[0];
+        expect(createElementArgs[0]).toBe('div');
+        expect(createElementArgs[1]?.textContent).toBe(message);
+        expect(createElementArgs[1]?.parent).toBe(document.body);
+        expect(createElementArgs[1]?.styles).toMatchObject({
+            ...toastBaseStylesFromNotificationService,
+            backgroundColor: toastTypeColors.success,
+            opacity: '0',
+            transform: 'translateY(20px)',
+        });
+
+        // 2. Verifica waitNextFrame
+        expect(mockDomServiceInstance.waitNextFrame).toHaveBeenCalledOnce();
+
+        // 3. Verifica applyStyles para animar a entrada
+        // Como waitNextFrame mockado resolve imediatamente (ou quase), applyStyles deve ser chamado.
+        // A primeira chamada a applyStyles pode ser DENTRO de createElementWithOptions se você configurou assim.
+        // A segunda chamada é para a animação de entrada.
+        // Vamos verificar a chamada específica da animação de entrada.
+        await vi.waitFor(() => { // Espera a promise do waitNextFrame e a subsequente applyStyles
+            expect(mockDomServiceInstance.applyStyles).toHaveBeenCalledWith(mockToastElement, {
+                opacity: '1',
+                transform: 'translateY(0)', // JSDOM pode adicionar 'px'
+            });
+        });
+
+        // Contagem total de chamadas para applyStyles pode variar.
+        // Se createElementWithOptions chama applyStyles:
+        // 1. Chamada dentro de createElementWithOptions (para estilos iniciais/base)
+        // 2. Chamada para animação de entrada
+        // 3. Chamada para animação de saída
+        // Verifique o número exato de chamadas se for importante, ou foque nos argumentos das chamadas específicas.
+        const fadeInStylesCall = mockDomServiceInstance.applyStyles.mock.calls.find(call => call[1].opacity === '1');
+        expect(fadeInStylesCall).toBeDefined();
+        expect(fadeInStylesCall?.[1]).toEqual({ opacity: '1', transform: 'translateY(0)' });
+
+
+        // 4. Avança timer para duração do toast
+        vi.advanceTimersByTime(3000);
+        const fadeOutStylesCall = mockDomServiceInstance.applyStyles.mock.calls.find(call => call[1].opacity === '0' && call[0] === mockToastElement);
+        expect(fadeOutStylesCall).toBeDefined();
+        expect(fadeOutStylesCall?.[1]).toEqual({
+            opacity: '0',
+            transform: 'translateY(20px)',
+        });
+
+        // 5. Avança timer para animação de saída
+        vi.advanceTimersByTime(300);
+        expect(mockToastElement.remove).toHaveBeenCalledOnce();
+    });
+
+    it('should create a warning toast with specified duration', async () => {
+        const message = 'Warning message';
+        const duration = 1000;
+        notificationService.showToast(message, 'warning', duration);
+
+        expect(mockDomServiceInstance.createElementWithOptions).toHaveBeenCalledOnce();
+        const createElementArgs = mockDomServiceInstance.createElementWithOptions.mock.calls[0];
+        expect(createElementArgs[1]?.styles?.backgroundColor).toBe(toastTypeColors.warning);
+
+        // Animação de entrada
+        await vi.waitFor(() => {
+            expect(mockDomServiceInstance.applyStyles).toHaveBeenCalledWith(mockToastElement, {
+                opacity: '1',
+                transform: 'translateY(0)',
+            });
+        });
+        
+        vi.advanceTimersByTime(duration); // Duração especificada
+        // Animação de saída
+        expect(mockDomServiceInstance.applyStyles).toHaveBeenCalledWith(mockToastElement, {
+            opacity: '0',
+            transform: 'translateY(20px)',
+        });
+
+        vi.advanceTimersByTime(300); // Fade-out
+        expect(mockToastElement.remove).toHaveBeenCalledOnce();
+    });
+
+    it('should create an error toast', () => {
+        notificationService.showToast('Error occurred', 'error');
+        expect(mockDomServiceInstance.createElementWithOptions).toHaveBeenCalledOnce();
+        const createElementArgs = mockDomServiceInstance.createElementWithOptions.mock.calls[0];
+        expect(createElementArgs[1]?.styles?.backgroundColor).toBe(toastTypeColors.error);
+    });
+
+    it('should use success color for unknown type', () => {
+        // @ts-expect-error: Testando um tipo inválido intencionalmente
+        notificationService.showToast('Unknown type toast', 'info');
+        expect(mockDomServiceInstance.createElementWithOptions).toHaveBeenCalledOnce();
+        const createElementArgs = mockDomServiceInstance.createElementWithOptions.mock.calls[0];
+        expect(createElementArgs[1]?.styles?.backgroundColor).toBe(toastTypeColors.success); // Fallback
+    });
+});

--- a/src/content/services/NotificationService.ts
+++ b/src/content/services/NotificationService.ts
@@ -85,9 +85,7 @@ export class NotificationService {
             });
 
             setTimeout(() => {
-                if (toastElement.parentNode) {
-                    toastElement.remove(); // Remoção padrão do DOM
-                }
+                  toastElement.remove(); 
             }, 300); // Duração da animação de saída
         }, duration);
     }

--- a/src/content/services/NotificationService.ts
+++ b/src/content/services/NotificationService.ts
@@ -4,6 +4,8 @@
  * It handles the creation, styling, animation, and removal of notification elements.
  */
 
+import { DomService } from './DomService';
+
 /** Base CSS styles for toast notifications. */
 const toastBaseStyles: Partial<CSSStyleDeclaration> = {
   position: 'fixed',
@@ -30,6 +32,7 @@ const toastTypeColors: Record<string, string> = {
 };
 
 export class NotificationService {
+  private domService: DomService;
   /**
    * Displays a toast notification on the page with a specified message, type, and duration.
    *
@@ -37,40 +40,55 @@ export class NotificationService {
    * @param {'success' | 'warning' | 'error'} [type='success'] The type of notification, determining its background color. Defaults to 'success'.
    * @param {number} [duration=3000] The duration in milliseconds for which the toast will be visible. Defaults to 3000ms.
    */
+
+  constructor(domService: DomService) { // Ou constructor(domService: DomService) se for injetar
+        this.domService = domService;
+    }
+
   showToast(
     message: string,
     type: 'success' | 'warning' | 'error' = 'success',
     duration: number = 3000
   ): void {
-    const toastElement = document.createElement('div');
-    toastElement.textContent = message;
+        const finalBaseStyles = { ...toastBaseStyles }; // Copia para não modificar o original
+        // Remove opacity e transform dos estilos base, pois serão aplicados na animação
+        delete finalBaseStyles.opacity;
+        delete finalBaseStyles.transform;
 
-    Object.assign(toastElement.style, toastBaseStyles);
-    toastElement.style.backgroundColor = toastTypeColors[type] || toastTypeColors.success; // Fallback to success color
+        const toastElement = this.domService.createElementWithOptions('div', {
+            textContent: message,
+            styles: {
+                ...finalBaseStyles, // Estilos base sem os de animação inicial
+                backgroundColor: toastTypeColors[type] || toastTypeColors.success,
+                // Estilos iniciais para animação (começa invisível e deslocado)
+                opacity: '0',
+                transform: 'translateY(20px)',
+            },
+            parent: document.body
+        });
 
-    document.body.appendChild(toastElement);
+        // Forçar reflow - opcional no teste, mas importante no browser
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        toastElement.offsetHeight;
 
-    // Force a reflow to ensure CSS transitions apply correctly from the initial state.
-    // Accessing offsetHeight is a common way to trigger this.
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    toastElement.offsetHeight;
+        this.domService.waitNextFrame().then(() => {
+            this.domService.applyStyles(toastElement, {
+                opacity: '1',
+                transform: 'translateY(0)' // Anima para a posição final
+            });
+        });
 
-    // Animate in: fade in and slide up
-    requestAnimationFrame(() => {
-      toastElement.style.opacity = '1';
-      toastElement.style.transform = 'translateY(0)';
-    });
+        setTimeout(() => {
+            this.domService.applyStyles(toastElement, {
+                opacity: '0',
+                transform: 'translateY(20px)' // Anima para sair
+            });
 
-    // Set up removal after the specified duration
-    setTimeout(() => {
-      toastElement.style.opacity = '0';
-      toastElement.style.transform = 'translateY(20px)'; // Animate out: fade out and slide down
-
-      // Wait for the fade-out animation to complete before removing the element from the DOM.
-      // This timeout should match the CSS transition duration (0.3s = 300ms).
-      setTimeout(() => {
-        toastElement.remove();
-      }, 300);
-    }, duration);
-  }
+            setTimeout(() => {
+                if (toastElement.parentNode) {
+                    toastElement.remove(); // Remoção padrão do DOM
+                }
+            }, 300); // Duração da animação de saída
+        }, duration);
+    }
 }


### PR DESCRIPTION
This pull request refactors the `NotificationService` to leverage the `DomService` for all its DOM manipulation tasks, such as element creation and styling. This is achieved by injecting `DomService` as a dependency into `NotificationService`, promoting better separation of concerns, improved testability, and centralized DOM logic.

**Key Changes:**

* **`NotificationService.ts` Refactoring**:
    * `DomService` is now a **constructor dependency** for `NotificationService`, allowing for easier mocking and more flexible usage.
    * The service now utilizes methods from the injected `DomService` instance (specifically `createElementWithOptions`, `applyStyles`, and `waitNextFrame`).
    * Logic for creating toast elements, applying initial and animation styles, and appending to the body is now fully handled via `DomService`.
    * Removed the `if (toastElement.parentNode)` check before `toastElement.remove()` to ensure consistent toast removal logic and simplify behavior in testing environments like JSDOM.

* **`NotificationService.test.ts` Updates**:
    * Tests were significantly adapted to mock the injected `DomService` dependency and its methods.
    * Assertions now verify that `NotificationService` correctly interacts with the `DomService` methods, passing the expected arguments, rather than directly spying on global DOM methods like `document.createElement` or `appendChild`.

This refactoring results in a `NotificationService` that is cleaner, more focused on its specific notification logic, and decoupled from direct DOM manipulation. Its tests are now true unit tests verifying the interaction with its `DomService` dependency.